### PR TITLE
Update LSP configurations and pin nvim-treesitter to master branch

### DIFF
--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -116,11 +116,20 @@ lspconfig.eslint.setup({
   end,
 })
 
--- Typo LSPの設定
-lspconfig.cspell.setup({
+-- Typo LSPの設定 (cspell-lsp は nvim-lspconfig 未登録のためカスタム定義)
+local lsp_configs = require("lspconfig.configs")
+if not lsp_configs.cspell_lsp then
+  lsp_configs.cspell_lsp = {
+    default_config = {
+      cmd = { "cspell-lsp", "--stdio" },
+      filetypes = { "*" },
+      root_dir = lspconfig.util.root_pattern(".git"),
+      single_file_support = true,
+    },
+  }
+end
+lspconfig.cspell_lsp.setup({
   capabilities = capabilities,
-  root_dir = lspconfig.util.root_pattern(".git"),
-  cmd = { "cspell-lsp" },
 })
 
 -- Python LSPの設定
@@ -140,7 +149,7 @@ lspconfig.pyright.setup({
 })
 
 -- Ruff LSPの設定
-lspconfig.ruff_lsp.setup({
+lspconfig.ruff.setup({
   capabilities = capabilities,
   filetypes = { "python" },
   root_dir = lspconfig.util.root_pattern(

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -9,7 +9,8 @@ Plug("nvim-tree/nvim-tree.lua")
 Plug("nvim-tree/nvim-web-devicons")
 
 -- telescope
-Plug("nvim-treesitter/nvim-treesitter", { ["do"] = ":TSUpdate" })
+-- upstream のデフォルトが main (新 API 書き直し版) に切り替わったため master を明示
+Plug("nvim-treesitter/nvim-treesitter", { ["do"] = ":TSUpdate", ["branch"] = "master" })
 
 -- theme
 Plug("projekt0n/github-nvim-theme")


### PR DESCRIPTION
## Summary
This PR updates LSP configurations to fix compatibility issues and pins nvim-treesitter to the master branch to maintain API stability.

## Key Changes
- **cspell LSP**: Migrated from built-in `cspell` to custom `cspell_lsp` configuration since cspell-lsp is not yet registered in nvim-lspconfig. Added proper custom LSP definition with stdio communication, wildcard filetype support, and git root detection.
- **Ruff LSP**: Updated from deprecated `ruff_lsp` to the current `ruff` server name in nvim-lspconfig.
- **nvim-treesitter**: Explicitly pinned to `master` branch instead of relying on upstream default, which has switched to the `main` branch containing a rewritten API. This ensures compatibility with existing configurations.

## Implementation Details
- The cspell_lsp custom configuration follows nvim-lspconfig patterns with `default_config` containing cmd, filetypes, root_dir, and single_file_support settings.
- Conditional check prevents re-registering cspell_lsp if it already exists in lspconfig.
- Removed redundant configuration options from cspell_lsp.setup() call since they're now defined in default_config.

https://claude.ai/code/session_01MSnspxzM5mPLuTb9bkJ3gT