### PR TITLE
feat(nvim): PHP LSPとして phpactor を追加

### DIFF
--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -198,6 +198,11 @@ lspconfig.phpactor.setup({
   filetypes = { "php" },
   root_dir = lspconfig.util.root_pattern("composer.json", ".phpactor.json", ".phpactor.yml", ".git"),
   single_file_support = true,
+  -- 起動時の "Phpstan/Psalm detected, enable extension?" プロンプトを抑制
+  init_options = {
+    ["language_server_phpstan.enabled"] = true,
+    ["language_server_psalm.enabled"] = true,
+  },
 })
 
 -- Lua LSPの設定

--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -198,8 +198,10 @@ lspconfig.phpactor.setup({
   filetypes = { "php" },
   root_dir = lspconfig.util.root_pattern("composer.json", ".phpactor.json", ".phpactor.yml", ".git"),
   single_file_support = true,
-  -- 起動時の "Phpstan/Psalm detected, enable extension?" プロンプトを抑制
+  -- 起動時の "Phpstan/Psalm detected, enable extension?" プロンプトを抑制し、
+  -- 拡張は明示的に有効化する
   init_options = {
+    ["language_server_configuration.auto_config"] = false,
     ["language_server_phpstan.enabled"] = true,
     ["language_server_psalm.enabled"] = true,
   },

--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -203,7 +203,9 @@ lspconfig.phpactor.setup({
   init_options = {
     ["language_server_configuration.auto_config"] = false,
     ["language_server_phpstan.enabled"] = true,
-    ["language_server_psalm.enabled"] = true,
+    -- psalm は enabled=true にすると vendor/bin/psalm が無いプロジェクトで
+    -- 毎回エラーになるため、必要なプロジェクトだけ .phpactor.json で有効化する
+    ["language_server_psalm.enabled"] = false,
   },
 })
 

--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -23,6 +23,7 @@ local servers = {
   "stylua",
   "lua_ls",
   "graphql",
+  "phpactor",
 }
 
 local unsupported_servers = { "cspell-lsp" }
@@ -187,6 +188,15 @@ lspconfig.ruff.setup({
     "Pipfile.lock",
     ".git"
   ),
+  single_file_support = true,
+})
+
+-- PHP LSPの設定
+lspconfig.phpactor.setup({
+  capabilities = capabilities,
+  cmd = { vim.fn.stdpath("data") .. "/mason/bin/phpactor", "language-server" },
+  filetypes = { "php" },
+  root_dir = lspconfig.util.root_pattern("composer.json", ".phpactor.json", ".phpactor.yml", ".git"),
   single_file_support = true,
 })
 


### PR DESCRIPTION
## Summary
- これまで PHP の LSP が未設定だったため、OSS (MIT) でアクティブメンテされている [phpactor](https://github.com/phpactor/phpactor) を追加
- `mason-lspconfig` の `ensure_installed` に追加して自動インストール
- `composer.json` / `.phpactor.json` / `.phpactor.yml` / `.git` をルートとして起動

## なぜ phpactor か
他候補（intelephense, phpantom_lsp, phptools）と比較した結果:
- intelephense は補完精度は高いが proprietary（freemium, $35）。既存 LSP 構成がすべて OSS で揃っているため一貫性を優先
- phpantom_lsp (Rust) は高速だが "active development" 段階で daily driver にはまだ早い
- phpactor は PHP 8.2+ 必須・最新リリース 2025.12.21 とアクティブで、補完・定義ジャンプ・リファクタリング一通り揃う

## Test plan
- [ ] `nvim` を起動して `:Mason` で `phpactor` が自動インストールされることを確認
- [ ] `.php` ファイルを開いて `:LspInfo` で `phpactor` が attach することを確認
- [ ] 補完・定義ジャンプ (`gd`)・hover (`K`) が動くことを確認

https://claude.ai/code/session_014y6nT5FqyjGCjAL6Z23i4t

---
_Generated by [Claude Code](https://claude.ai/code/session_014y6nT5FqyjGCjAL6Z23i4t)_